### PR TITLE
Fix TimeSpan to be an int

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,4 +48,4 @@ server.listen(8080);
 
 console.log("Started server on Port 8080");
 console.log("GraphiQL (API Explorer + Rendered Docs) available at: http://localhost:8080/api");
-console.log("API-Endpoint: http://[SERVER-IP]:8080/api")
+console.log("API-Endpoint: http://[SERVER-IP]:8080/api");

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const mockData: IMocks = {
     String: () => "A text",
     JSON: () => JSON.stringify({ this: "is", a: ["test"] }),
     Colour: randomColor,
-    TimeSpan: () => Math.random() * 31536000000,
+    TimeSpan: () => Math.floor(Math.random() * 31536000000),
     Date: () => new Date().toISOString(),
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const mockData: IMocks = {
     String: () => "A text",
     JSON: () => JSON.stringify({ this: "is", a: ["test"] }),
     Colour: randomColor,
-    TimeSpan: () => Math.floor(Math.random() * 31536000000),
+    TimeSpan: () => Math.floor(Math.random() * 2**31),
     Date: () => new Date().toISOString(),
 }
 


### PR DESCRIPTION
With the previous implementation it may be a float.

## Preparations
Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## :ticket: Description


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
The api mockup may return a float for the TimeSpan type.


* **What is the new behavior (if this is a feature change)?**
Only ints are returned for the TimeSpan type.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
If anyone relies on TimeSpan being a float this will cause problems.


* **Other information**:
The documentation states, that TimeSpan is the number of milliseconds as an int.

## :lock: Closes
Which issue(s) is (are) being closed by the PR?


