### PR TITLE
Add stable ids with type information to mocks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import { mockServer, IMocks, IMockOptions, addMocksToSchema } from "graphql-tools";
-import * as graphql from "graphql";
+import { IMocks, IMockOptions, addMocksToSchema, makeExecutableSchema } from "graphql-tools";
 import { readFileSync } from "fs";
 import express from "express";
 import { graphqlHTTP, Options } from "express-graphql";
@@ -13,7 +12,44 @@ function randomColor(): string {
 }
 
 const schemaFile = readFileSync("schemas/schema.graphql").toString();
-const schema = graphql.buildSchema(schemaFile);
+const schema = makeExecutableSchema({
+    typeDefs: schemaFile,
+});
+
+const nodeTypes: string[] = [
+    'User',
+    'Project',
+    'Component',
+    'ComponentInterface',
+    'Label',
+    'Issue',
+    'IssueComment',
+    'DeletedIssueComment',
+    'ReferencedByOtherEvent',
+    'ReferencedByIssueEvent',
+    'LinkEvent',
+    'UnlinkEvent',
+    'WasLinkedEvent',
+    'WasUnlinkedEvent',
+    'LabelledEvent',
+    'UnlabelledEvent',
+    'PinnedEvent',
+    'UnpinnedEvent',
+    'RenamedTitleEvent',
+    'CategoryChangedEvent',
+    'AssignedEvent',
+    'UnassignedEvent',
+    'ClosedEvent',
+    'ReopenedEvent',
+    'PriorityChangedEvent',
+    'StartDateChangedEvent',
+    'DueDateChangedEvent',
+    'EstimatedTimeChangedEvent',
+    'AddedLocationEvent',
+    'RemovedLocationEvent',
+    'MarkedAsDuplicateEvent',
+    'UnmarkedAsDuplicateEvent',
+];
 
 const mockData: IMocks = {
     Int: () => 0,
@@ -22,7 +58,38 @@ const mockData: IMocks = {
     Colour: randomColor,
     TimeSpan: () => Math.floor(Math.random() * 2**31),
     Date: () => new Date().toISOString(),
+    // resolve node type based on id prefix
+    Node: (root, { id }) => {
+        const nodeType = nodeTypes.find(nodeType => id.startsWith(nodeType));
+        if (nodeType != null) {
+            return {
+                id,
+                __typename: nodeType,
+            }
+        }
+        // return a default type, maybe change this to a random type
+        return {
+            id,
+            __typename: 'Project',
+        }
+    },
 }
+
+// add ID generators with the correct id prefix and simple counting ids to the mock resolvers
+nodeTypes.forEach(nodeType => {
+    let lastId = 0;
+    mockData[nodeType] = (root, {id}) => {
+        if (id != null) {
+            return {id}
+        }
+
+        lastId++;
+        const newId = lastId;
+        return {
+            id: `${nodeType}_${newId}`,
+        };
+    };
+});
 
 const mockOptions: IMockOptions = {
     mocks: mockData,


### PR DESCRIPTION
## Preparations
Please check if the PR fulfills these requirements
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## :ticket: Description


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

With this PR object ids should not change (for most use cases of the mock) and retain type information making the node query usable in the mock.

* **What is the current behavior?** (You can also link to an open issue here)

The node query returns random objects with random ids and of a random type.

* **What is the new behavior (if this is a feature change)?**

The node query keeps the requested id and uses it to deterministically decide which type of object to generate.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Mocked object ids have a new format (`<type>_<counter>` example: `Project_1`).

* **Other information**:


## :lock: Closes
Which issue(s) is (are) being closed by the PR?


